### PR TITLE
Fix check for lack of time information in the entry datetime

### DIFF
--- a/sphinxcontrib/newsfeed.py
+++ b/sphinxcontrib/newsfeed.py
@@ -90,7 +90,7 @@ class FeedEntryDirective(Directive):
         if date:
             meta_node += nodes.Text(' on ')
             date_node = nodes.emphasis(classes=['feed-date'])
-            if not date.time():
+            if date.time() == datetime.time():  # Check for zero time information
                 date_node += nodes.Text(date.date())
             else:
                 date_node += nodes.Text(date)


### PR DESCRIPTION
`if not date.time()` worked in Python 3.4 and previous, cf. https://stackoverflow.com/questions/1423673/finding-if-a-python-datetime-has-no-time-information