### PR TITLE
Fix erroneous "doc" usage

### DIFF
--- a/sphinxcontrib/newsfeed.py
+++ b/sphinxcontrib/newsfeed.py
@@ -78,7 +78,7 @@ class FeedEntryDirective(Directive):
             else:
                 break
         else:
-            return [doc.reporter.error("invalid date `%s`" % date,
+            return [self.reporter.error("invalid date `%s`" % date,
                                        lineno=self.lineno)]
         meta_node = entrymeta(classes=['feed-meta'])
         meta_node += nodes.Text('Published')


### PR DESCRIPTION
I believe this intended to use the Directive.reporter cf. https://github.com/docutils/docutils/blob/c7c4d21c4a439552dace1d924e5bd845db070296/docutils/docutils/parsers/rst/__init__.py#L330