### PR TITLE
Fix RSS item description rendering for Sphinx 9.1+

### DIFF
--- a/sphinxcontrib/newsfeed.py
+++ b/sphinxcontrib/newsfeed.py
@@ -265,8 +265,9 @@ def process_feed(app, doctree, fromdocname):
                 replacement.append(section_node)
                 env.resolve_references(rss_item_description, docname, app.builder)
                 if app.builder.format == 'html':
-                    rss_item_description = app.builder.render_partial(
-                                                    rss_item_description)['body']
+                    rendered = app.builder.render_partial(rss_item_description)
+                    # Sphinx 9.1+ changed 'body' to 'fragment'
+                    rss_item_description = rendered.get('fragment', rendered.get('body', ''))
                     rss_item_date = meta['date']
                     rss_item = RSSItem(rss_item_title, rss_item_link,
                                        rss_item_description, rss_item_date)


### PR DESCRIPTION
# Fix Sphinx 9.1 Compatibility Issue

## Summary

This PR fixes a compatibility issue with Sphinx 9.1+ where the extension fails with `KeyError: 'body'` during RSS feed generation.

## Problem

After updating to Sphinx 9.1, the extension crashes with the following error:

```
Extension error (sphinxcontrib.newsfeed)!
...
Handler <function process_feed at 0x...> for event 'doctree-resolved' threw an exception (exception: 'body')
```

**Root Cause**: Sphinx 9.1 changed the return value structure of the `HTMLBuilder.render_partial()` method. Previously it returned a dictionary with a `'body'` key, but now it returns `'fragment'` and `'title'` keys instead.

### Sphinx API Change

**Before (Sphinx < 9.1):**
```python
render_partial(node) → {'body': '...', ...}
```

**After (Sphinx 9.1+):**
```python
render_partial(node) → {'fragment': '...', 'title': '...'}
```

## Solution

Updated the code in `process_feed()` function (line 268-270) to be backwards-compatible with both old and new Sphinx versions:

```python
rendered = app.builder.render_partial(rss_item_description)
# Sphinx 9.1+ changed 'body' to 'fragment'
rss_item_description = rendered.get('fragment', rendered.get('body', ''))
```

This approach:
- ✅ Works with Sphinx 9.1+ (uses `'fragment'` key)
- ✅ Maintains backwards compatibility with older Sphinx versions (falls back to `'body'` key)
- ✅ Gracefully handles both cases with no breaking changes

## Testing

Tested with:
- ✅ Sphinx 9.1.0
- ✅ Python 3.13.11
- ✅ Docutils 0.22.4

The extension now successfully generates RSS feeds without errors.

## Related Issues

- Sphinx issue: https://github.com/sphinx-doc/sphinx/issues/14272

## Compatibility

- **Minimum Sphinx version**: No change (still supports older versions)
- **Maximum Sphinx version**: Now supports Sphinx 9.1+
- **Breaking changes**: None

